### PR TITLE
Postdeploy codebuild

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -91,6 +91,8 @@ variable "ecs_services" {
       taskdef_container_definitions      = string
       codepipeline_container_definitions = string
 
+      postdeploy_codebuild_project_name = list(string)
+
       # task_definition = string
     }
   ))

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -82,6 +82,23 @@ resource "aws_codepipeline" "this" {
         TaskDefinitionTemplatePath     = "taskdef.json"
       }
     }
+    dynamic "action" {
+      for_each = var.ecs_services[each.key].postdeploy_codebuild_project_name
+      content {
+        category = "Build"
+        name = "PostDeploy_CodeBuild"
+        owner = "AWS"
+        provider = "CodeBuild"
+        version = "1"
+        run_order = 3
+        input_artifacts = ["ArtifactsECR", "ArtifactsS3"]
+        output_artifacts = []
+
+        configuration = {
+          ProjectName = join("", var.ecs_services[each.key].postdeploy_codebuild_project_name)
+        }
+      }
+    }
   }
 
   dynamic "stage" {

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -85,14 +85,14 @@ resource "aws_codepipeline" "this" {
     dynamic "action" {
       for_each = var.ecs_services[each.key].postdeploy_codebuild_project_name
       content {
-        category = "Build"
-        name = "PostDeploy_CodeBuild"
-        owner = "AWS"
-        provider = "CodeBuild"
-        version = "1"
-        run_order = 3
-        input_artifacts = ["ArtifactsECR", "ArtifactsS3"]
-        output_artifacts = []
+        category          = "Build"
+        name              = "PostDeploy_CodeBuild"
+        owner             = "AWS"
+        provider          = "CodeBuild"
+        version           = "1"
+        run_order         = 3
+        input_artifacts   = ["ArtifactsECR", "ArtifactsS3"]
+        output_artifacts  = []
 
         configuration = {
           ProjectName = join("", var.ecs_services[each.key].postdeploy_codebuild_project_name)

--- a/codepipeline.tf
+++ b/codepipeline.tf
@@ -91,7 +91,7 @@ resource "aws_codepipeline" "this" {
         provider          = "CodeBuild"
         version           = "1"
         run_order         = 3
-        input_artifacts   = ["ArtifactsECR", "ArtifactsS3"]
+        input_artifacts   = ["ArtifactsECR"]
         output_artifacts  = []
 
         configuration = {


### PR DESCRIPTION
## Change description

> Description here

CodeBuild requires a "primary source" when declaring two input artifacts. Instead of declaring these, I changed the input_artifacts to just ArtifactsECR.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
