### PR TITLE
Deprecate termination_wait_time

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -28,7 +28,7 @@ variable "input_tags" {
 }
 
 variable "termination_wait_time" {
-  description = "Termination wait time for blue green deployments"
+  description = "Deprecated. Use codedeploy_termination_wait_time in the ecs_services object instead."
   type        = number
   default     = 5
 }

--- a/codedeploy.tf
+++ b/codedeploy.tf
@@ -25,7 +25,7 @@ resource "aws_codedeploy_deployment_group" "this" {
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
-      termination_wait_time_in_minutes = var.termination_wait_time
+      termination_wait_time_in_minutes = var.ecs_services[each.key].codedeploy_termination_wait_time
     }
   }
 


### PR DESCRIPTION
## Change description
Deprecates the variable `termination_wait_time`. There is a variable in the `ecs_services` object that serves the same purpose. Leaving the variable in `-inputs` for now in order to avoid breaking changes, but we should remove it at the next major version change.

This could cause unexpected behavior because it will "turn on" the `codedeploy_termination_wait_time` variable when before it had no effect. However, the impact would be minimal, being a change to the blue/green wait time.