### PR TITLE
Ecs service capacity provider

### DIFF
--- a/-inputs.tf
+++ b/-inputs.tf
@@ -55,6 +55,9 @@ variable "ecs_services" {
 
       service_registries = map(string)
 
+      use_custom_capacity_provider_strategy = bool
+      custom_capacity_provider_strategy = map(string)
+
       health_check_grace_period_seconds = number
 
       lb_listener_prod_arn       = string

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ module "ecs_fargate_app" {
         registry_arn = aws_service_discovery_service.discovery_service.arn
       }
 
+      use_custom_capacity_provider_strategy = true
       capacity_provider_strategy = { // must do block for each capacity provider
         base              = 1
         capacity_provider = "FARGATE"

--- a/README.md
+++ b/README.md
@@ -99,13 +99,7 @@ module "ecs_fargate_app" {
       service_registries = { // only accepts a single block
         registry_arn = aws_service_discovery_service.discovery_service.arn
       }
-
-      use_custom_capacity_provider_strategy = true
-      capacity_provider_strategy = { // must do block for each capacity provider
-        base              = 1
-        capacity_provider = "FARGATE"
-        weight            = 0        
-      }
+      
       # load balancer configs
       health_check_grace_period_seconds = 10
       

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ module "ecs_fargate_app" {
         registry_arn = aws_service_discovery_service.discovery_service.arn
       }
 
+      capacity_provider_strategy = { // must do block for each capacity provider
+        base              = 1
+        capacity_provider = "FARGATE"
+        weight            = 0        
+      }
       # load balancer configs
       health_check_grace_period_seconds = 10
       

--- a/ecs-cluster.tf
+++ b/ecs-cluster.tf
@@ -1,6 +1,6 @@
 # cluster
 resource "aws_ecs_cluster" "this" {
-  name = var.ecs_cluster_name
-  tags = merge(var.input_tags, {})
+  name                = var.ecs_cluster_name
+  tags                = merge(var.input_tags, {})
+  capacity_providers  = ["FARGATE", "FARGATE_SPOT"]
 }
-


### PR DESCRIPTION
…ATE_SPOT

## Change description

> Description here

This change came about with the need to scale the ECS service's task with FARGATE_SPOT when triggered by the threshold's alarm created outside this module. 

The change introduces a dynamic block of a capacity provider strategy to create a strategy created on implementation in the locals file (outside this module) when deployed. Since "launch_type" and "capacity_provider_strategy" cannot exist within the same service, "launch type" is referencing a locals bool variable (outside this module) that determines to use either the "launch_type" or "capacity_provider_strategy". 

Since the ECS service is controlled with CodeDeploy, the appspec.yaml file is the source of truth on all deployments. To implement a capacity strategy in the service, the appspec file creation is dynamically created based off the boolean of the variable in the locals file. 

Lastly, since this module was created for FARGATE deployment only, the capacity providers of "FARGATE" and "FARGATE_SPOT" were hardcoded in the ecs cluster. This value is hardcoded since these values are not affected if one decides to use FARGATE_SPOT or not. This just gives the cluster the option to use the capacity providers. 

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
