### PR TITLE
Remove need to do a targeted apply

### DIFF
--- a/codepipeline-artifacts.tf
+++ b/codepipeline-artifacts.tf
@@ -6,7 +6,7 @@ resource "aws_s3_bucket_object" "artifacts_s3" {
   bucket = var.ecs_services[each.key].codepipeline_source_bucket_id
   key    = var.ecs_services[each.key].codepipeline_source_object_key
   source = data.archive_file.artifacts[each.key].output_path
-  etag   = filemd5(data.archive_file.artifacts[each.key].output_path)
+  source_hash = md5(jsonencode(data.archive_file.artifacts[each.key].source))
 }
 
 data "archive_file" "artifacts" {


### PR DESCRIPTION
## Change description

Changed from using the etag hash from s3 to making an md5 of the source content we are zipping up and storing that in state for comparison with the source_hash. This was done to allow the hash value to be computed in a later phase than terraform was doing it using the hash of the file itself compared to the etag, since it could only create the zip file after it had applied dependencies (which we have been targeting up till now), but it can do all of it in the apply phase this way.

I have tested the following:
- Changing the ports in the container task definition - Changed on the first shot and didn't want to keep updating after a single good apply
- Changing the CPU and Memory of the task - Showed it changing the version and source hash for the resources on the first go. Applied, and on the second go it came back clean. I downloaded the zip and verified it was changing the value in the task definition in the zip.

## Type of change
- [ ] Bug fix (fixes an issue)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
